### PR TITLE
[#30] graphql directive 를 활용한 인가기능 구현

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,5 +27,12 @@ jobs:
         with:
           arguments: test
 
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v2
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check files are changed
         run: git diff --exit-code

--- a/app/src/main/kotlin/com/santaclose/app/AppApplication.kt
+++ b/app/src/main/kotlin/com/santaclose/app/AppApplication.kt
@@ -1,14 +1,29 @@
 package com.santaclose.app
 
+import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
+import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
+import com.santaclose.app.auth.directive.AuthSchemaDirectiveWiring
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @EnableJpaAuditing
 @SpringBootApplication
 @EntityScan(basePackages = ["com.santaclose.lib.entity"])
-class AppApplication
+class AppApplication {
+    @Bean
+    fun wiringFactory() = KotlinDirectiveWiringFactory(
+        manualWiring = mapOf("auth" to AuthSchemaDirectiveWiring())
+    )
+
+    @Bean
+    fun hooks(wiringFactory: KotlinDirectiveWiringFactory) = object : SchemaGeneratorHooks {
+        override val wiringFactory: KotlinDirectiveWiringFactory
+            get() = wiringFactory
+    }
+}
 
 fun main(args: Array<String>) {
     runApplication<AppApplication>(*args)

--- a/app/src/main/kotlin/com/santaclose/app/auth/context/AppGraphQLContextFactory.kt
+++ b/app/src/main/kotlin/com/santaclose/app/auth/context/AppGraphQLContextFactory.kt
@@ -1,0 +1,21 @@
+package com.santaclose.app.auth.context
+
+import arrow.core.toOption
+import com.expediagroup.graphql.server.spring.execution.SpringGraphQLContext
+import com.expediagroup.graphql.server.spring.execution.SpringGraphQLContextFactory
+import com.santaclose.lib.entity.appUser.AppUser
+import com.santaclose.lib.entity.appUser.type.AppUserRole
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
+
+@Component
+class AppGraphQLContextFactory : SpringGraphQLContextFactory<SpringGraphQLContext>() {
+    override suspend fun generateContextMap(request: ServerRequest): Map<*, Any>? {
+        return mapOf(
+            "user" to AppUser("01011112222", "socialId", AppUserRole.USER).toOption(),
+            "request" to request,
+        )
+    }
+
+    override suspend fun generateContext(request: ServerRequest): SpringGraphQLContext? = null
+}

--- a/app/src/main/kotlin/com/santaclose/app/auth/context/DataFetchingEnvironmentExtension.kt
+++ b/app/src/main/kotlin/com/santaclose/app/auth/context/DataFetchingEnvironmentExtension.kt
@@ -1,0 +1,7 @@
+package com.santaclose.app.auth.context
+
+import arrow.core.Option
+import com.santaclose.lib.entity.appUser.AppUser
+import graphql.schema.DataFetchingEnvironment
+
+fun DataFetchingEnvironment.user(): Option<AppUser> = this.graphQlContext.get("user")

--- a/app/src/main/kotlin/com/santaclose/app/auth/directive/Auth.kt
+++ b/app/src/main/kotlin/com/santaclose/app/auth/directive/Auth.kt
@@ -1,0 +1,12 @@
+package com.santaclose.app.auth.directive
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDirective
+import com.santaclose.lib.entity.appUser.type.AppUserRole
+import graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION
+
+@GraphQLDirective(
+    name = "auth",
+    description = "authorization",
+    locations = [FIELD_DEFINITION]
+)
+annotation class Auth(val role: AppUserRole)

--- a/app/src/main/kotlin/com/santaclose/app/auth/directive/AuthSchemaDirectiveWiring.kt
+++ b/app/src/main/kotlin/com/santaclose/app/auth/directive/AuthSchemaDirectiveWiring.kt
@@ -1,0 +1,36 @@
+package com.santaclose.app.auth.directive
+
+import arrow.core.Option
+import arrow.core.handleErrorWith
+import com.expediagroup.graphql.generator.directives.KotlinFieldDirectiveEnvironment
+import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
+import com.santaclose.lib.entity.appUser.AppUser
+import com.santaclose.lib.entity.appUser.type.AppUserRole
+import com.santaclose.lib.web.error.UnauthorizedException
+import com.santaclose.lib.web.error.toGraphQLException
+import graphql.GraphQLException
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLFieldDefinition
+
+class AuthSchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
+    override fun onField(environment: KotlinFieldDirectiveEnvironment): GraphQLFieldDefinition {
+        val role = environment.directive.getArgument("role").argumentValue.value.let {
+            when (it) {
+                is AppUserRole -> it
+                else -> throw GraphQLException("invalid app user role: $it")
+            }
+        }
+        val originalDataFetcher = environment.getDataFetcher()
+
+        val authDataFetcher = DataFetcher { dfe ->
+            dfe.graphQlContext.get<Option<AppUser>>("user")
+                .filter { user -> user.hasRole(role) }
+                .handleErrorWith { throw UnauthorizedException("접근 권한이 없습니다").toGraphQLException() }
+
+            originalDataFetcher.get(dfe)
+        }
+        environment.setDataFetcher(authDataFetcher)
+
+        return environment.element
+    }
+}

--- a/app/src/main/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolver.kt
+++ b/app/src/main/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolver.kt
@@ -2,9 +2,11 @@ package com.santaclose.app.sample.resolver
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.server.operations.Query
+import com.santaclose.app.auth.directive.Auth
 import com.santaclose.app.sample.resolver.dto.SampleAppDetail
 import com.santaclose.app.sample.resolver.dto.SampleAppItemInput
 import com.santaclose.app.sample.service.SampleAppQueryService
+import com.santaclose.lib.entity.appUser.type.AppUserRole
 import com.santaclose.lib.web.error.getOrThrow
 import org.springframework.stereotype.Component
 import org.springframework.validation.annotation.Validated
@@ -15,6 +17,7 @@ import javax.validation.Valid
 class SampleAppQueryResolver(
     private val sampleAppQueryService: SampleAppQueryService,
 ) : Query {
+    @Auth(AppUserRole.USER)
     @GraphQLDescription("샘플 데이터")
     fun sample(@Valid input: SampleAppItemInput): SampleAppDetail =
         sampleAppQueryService

--- a/app/src/main/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolver.kt
+++ b/app/src/main/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolver.kt
@@ -8,7 +8,6 @@ import com.santaclose.app.sample.resolver.dto.SampleAppItemInput
 import com.santaclose.app.sample.service.SampleAppQueryService
 import com.santaclose.lib.entity.appUser.type.AppUserRole
 import com.santaclose.lib.web.error.getOrThrow
-import graphql.schema.DataFetchingEnvironment
 import org.springframework.stereotype.Component
 import org.springframework.validation.annotation.Validated
 import javax.validation.Valid
@@ -20,7 +19,7 @@ class SampleAppQueryResolver(
 ) : Query {
     @Auth(AppUserRole.USER)
     @GraphQLDescription("샘플 데이터")
-    fun sample(@Valid input: SampleAppItemInput, dfe: DataFetchingEnvironment): SampleAppDetail =
+    fun sample(@Valid input: SampleAppItemInput): SampleAppDetail =
         sampleAppQueryService
             .findByPrice(input.price)
             .getOrThrow()

--- a/app/src/main/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolver.kt
+++ b/app/src/main/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolver.kt
@@ -8,6 +8,7 @@ import com.santaclose.app.sample.resolver.dto.SampleAppItemInput
 import com.santaclose.app.sample.service.SampleAppQueryService
 import com.santaclose.lib.entity.appUser.type.AppUserRole
 import com.santaclose.lib.web.error.getOrThrow
+import graphql.schema.DataFetchingEnvironment
 import org.springframework.stereotype.Component
 import org.springframework.validation.annotation.Validated
 import javax.validation.Valid
@@ -19,7 +20,7 @@ class SampleAppQueryResolver(
 ) : Query {
     @Auth(AppUserRole.USER)
     @GraphQLDescription("샘플 데이터")
-    fun sample(@Valid input: SampleAppItemInput): SampleAppDetail =
+    fun sample(@Valid input: SampleAppItemInput, dfe: DataFetchingEnvironment): SampleAppDetail =
         sampleAppQueryService
             .findByPrice(input.price)
             .getOrThrow()

--- a/app/src/main/resources/graphql/schema.graphql
+++ b/app/src/main/resources/graphql/schema.graphql
@@ -15,6 +15,9 @@ directive @skip(
     if: Boolean!
   ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"authorization"
+directive @auth(role: AppUserRole!) on FIELD_DEFINITION
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
@@ -33,13 +36,18 @@ type Mutation {
 
 type Query {
   "샘플 데이터"
-  sample(input: SampleAppItemInput!): SampleAppDetail!
+  sample(input: SampleAppItemInput!): SampleAppDetail! @auth(role : USER)
 }
 
 type SampleAppDetail {
   name: String!
   price: Int!
   status: SampleStatus!
+}
+
+enum AppUserRole {
+  USER
+  VIEWER
 }
 
 enum SampleStatus {

--- a/app/src/test/kotlin/com/santaclose/app/auth/directive/AuthSchemaDirectiveWiringTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/auth/directive/AuthSchemaDirectiveWiringTest.kt
@@ -1,0 +1,111 @@
+package com.santaclose.app.auth.directive
+
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.toOption
+import com.expediagroup.graphql.generator.directives.KotlinFieldDirectiveEnvironment
+import com.santaclose.lib.entity.appUser.AppUser
+import com.santaclose.lib.entity.appUser.type.AppUserRole
+import graphql.GraphQLException
+import graphql.GraphqlErrorException
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class AuthSchemaDirectiveWiringTest {
+    private val authSchemaDirectiveWiring = AuthSchemaDirectiveWiring()
+
+    @Nested
+    inner class OnField {
+        @Test
+        fun `유효한 파라미터가 아니라면 에러가 발생한다`() {
+            // given
+            val envMock = mockk<KotlinFieldDirectiveEnvironment>()
+            every { envMock.directive.getArgument("role").argumentValue.value } returns "invalid"
+
+            // when
+            val exception = shouldThrow<GraphQLException> {
+                authSchemaDirectiveWiring.onField(envMock)
+            }
+
+            // then
+            exception.message shouldBe "invalid app user role: invalid"
+        }
+
+        @Test
+        fun `익명 사용자가 요청 시 에러가 발생한다`() {
+            // given
+            val envMock = mockk<KotlinFieldDirectiveEnvironment>(relaxed = true)
+            val slot = slot<DataFetcher<Any>>()
+
+            every { envMock.directive.getArgument("role").argumentValue.value } returns AppUserRole.USER
+            every { envMock.element } returns mockk()
+            every { envMock.setDataFetcher(capture(slot)) } returns Unit
+
+            // when
+            authSchemaDirectiveWiring.onField(envMock)
+
+            // then
+            val fetchEnvMock = mockk<DataFetchingEnvironment>()
+            every { fetchEnvMock.graphQlContext.get<Option<AppUser>>("user") } returns None
+            shouldThrow<GraphqlErrorException> {
+                slot.captured.get(fetchEnvMock)
+            }.apply {
+                message shouldBe "접근 권한이 없습니다"
+            }
+        }
+
+        @Test
+        fun `권한없는 사용자가 요청 시 에러가 발생한다`() {
+            // given
+            val envMock = mockk<KotlinFieldDirectiveEnvironment>(relaxed = true)
+            val slot = slot<DataFetcher<Any>>()
+
+            every { envMock.directive.getArgument("role").argumentValue.value } returns AppUserRole.USER
+            every { envMock.element } returns mockk()
+            every { envMock.setDataFetcher(capture(slot)) } returns Unit
+
+            // when
+            authSchemaDirectiveWiring.onField(envMock)
+
+            // then
+            val fetchEnvMock = mockk<DataFetchingEnvironment>()
+            val appUser = AppUser("11", "id", AppUserRole.VIEWER)
+            every { fetchEnvMock.graphQlContext.get<Option<AppUser>>("user") } returns appUser.toOption()
+
+            shouldThrow<GraphqlErrorException> {
+                slot.captured.get(fetchEnvMock)
+            }.apply {
+                message shouldBe "접근 권한이 없습니다"
+            }
+        }
+
+        @Test
+        fun `권한있는 사용자가 요청 시 에러가 발생하지 않는다`() {
+            // given
+            val envMock = mockk<KotlinFieldDirectiveEnvironment>(relaxed = true)
+            val slot = slot<DataFetcher<Any>>()
+
+            every { envMock.directive.getArgument("role").argumentValue.value } returns AppUserRole.USER
+            every { envMock.element } returns mockk()
+            every { envMock.setDataFetcher(capture(slot)) } returns Unit
+
+            // when
+            authSchemaDirectiveWiring.onField(envMock)
+
+            // then
+            val fetchEnvMock = mockk<DataFetchingEnvironment>()
+            val appUser = AppUser("11", "id", AppUserRole.USER)
+            every { fetchEnvMock.graphQlContext.get<Option<AppUser>>("user") } returns appUser.toOption()
+
+            shouldNotThrowAny { slot.captured.get(fetchEnvMock) }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/santaclose/app/sample/repository/SampleAppQueryRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/sample/repository/SampleAppQueryRepositoryImplTest.kt
@@ -42,7 +42,7 @@ internal class SampleAppQueryRepositoryImplTest : TestQueryFactory() {
                 em.persist(sample)
             }
 
-            exception.message shouldContain "0보다 커야 합니다"
+            exception.message shouldContain "javax.validation.constraints.Positive"
         }
     }
 }

--- a/app/src/test/kotlin/com/santaclose/app/sample/repository/SampleAppQueryRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/sample/repository/SampleAppQueryRepositoryImplTest.kt
@@ -5,9 +5,12 @@ import com.santaclose.app.util.TestQueryFactory
 import com.santaclose.lib.entity.sample.Sample
 import com.santaclose.lib.entity.sample.type.SampleStatus
 import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import javax.validation.ConstraintViolationException
 
 @DataJpaTest
 internal class SampleAppQueryRepositoryImplTest : TestQueryFactory() {
@@ -30,6 +33,16 @@ internal class SampleAppQueryRepositoryImplTest : TestQueryFactory() {
             result shouldBeRight sample.run {
                 SampleAppDetail(name, price, status)
             }
+        }
+
+        @Test
+        fun `bean validation 이 정상적으로 동작한다`() {
+            val exception = shouldThrow<ConstraintViolationException> {
+                val sample = Sample("test", -123, SampleStatus.OPEN)
+                em.persist(sample)
+            }
+
+            exception.message shouldContain "0보다 커야 합니다"
         }
     }
 }

--- a/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
@@ -33,7 +33,15 @@ internal class SampleAppQueryResolverTest @Autowired constructor(
         @Test
         fun `데이터가 없는 경우 에러가 발생한다`() {
             // given
-            val query = QueryInput("query { sample(input: {price: 123}) { name price status }}")
+            val query = QueryInput(
+                """query {
+                |  sample(input: {price: 123}) {
+                |    name
+                |    price
+                |    status
+                |  }
+                |}""".trimMargin()
+            )
             every { sampleAppQueryService.findByPrice(123) } returns NoResultException("no result").left()
 
             // when
@@ -46,7 +54,15 @@ internal class SampleAppQueryResolverTest @Autowired constructor(
         @Test
         fun `데이터가 있는 경우 sample 을 가져온다`() {
             // given
-            val query = QueryInput("query { sample(input: {price: 123}) { name price status }}")
+            val query = QueryInput(
+                """query {
+                |  sample(input: {price: 123}) {
+                |    name
+                |    price
+                |    status
+                |  }
+                |}""".trimMargin()
+            )
             val dto = SampleAppDetail("name", 1000, SampleStatus.OPEN).right()
             every { sampleAppQueryService.findByPrice(123) } returns dto
 

--- a/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
@@ -45,7 +45,7 @@ internal class SampleAppQueryResolverTest @Autowired constructor(
                 |}""".trimMargin()
             )
             every { sampleAppQueryService.findByPrice(123) } returns NoResultException("no result").left()
-            withMockUser(AppUserRole.VIEWER)
+            withAnonymousUser()
 
             // when
             val response = webTestClient.query(query)

--- a/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
@@ -5,11 +5,13 @@ import arrow.core.right
 import com.ninjasquad.springmockk.MockkBean
 import com.santaclose.app.sample.resolver.dto.SampleAppDetail
 import com.santaclose.app.sample.service.SampleAppQueryService
+import com.santaclose.app.util.AppContextMocker
 import com.santaclose.app.util.QueryInput
 import com.santaclose.app.util.query
 import com.santaclose.app.util.success
 import com.santaclose.app.util.verify
 import com.santaclose.app.util.verifyError
+import com.santaclose.lib.entity.appUser.type.AppUserRole
 import com.santaclose.lib.entity.sample.type.SampleStatus
 import com.santaclose.lib.web.error.GraphqlErrorCode
 import io.mockk.every
@@ -27,9 +29,31 @@ internal class SampleAppQueryResolverTest @Autowired constructor(
     private val webTestClient: WebTestClient,
     @MockkBean
     private val sampleAppQueryService: SampleAppQueryService,
-) {
+) : AppContextMocker() {
     @Nested
     inner class Sample {
+        @Test
+        fun `권한없는 유저가 요청 시 에러가 발생한다`() {
+            // given
+            val query = QueryInput(
+                """query {
+                |  sample(input: {price: 123}) {
+                |    name
+                |    price
+                |    status
+                |  }
+                |}""".trimMargin()
+            )
+            every { sampleAppQueryService.findByPrice(123) } returns NoResultException("no result").left()
+            withMockUser(AppUserRole.VIEWER)
+
+            // when
+            val response = webTestClient.query(query)
+
+            // then
+            response.verifyError(GraphqlErrorCode.UNAUTHORIZED, "Exception while fetching data (/sample) : 접근 권한이 없습니다")
+        }
+
         @Test
         fun `데이터가 없는 경우 에러가 발생한다`() {
             // given
@@ -43,6 +67,7 @@ internal class SampleAppQueryResolverTest @Autowired constructor(
                 |}""".trimMargin()
             )
             every { sampleAppQueryService.findByPrice(123) } returns NoResultException("no result").left()
+            withMockUser(AppUserRole.USER)
 
             // when
             val response = webTestClient.query(query)
@@ -65,6 +90,7 @@ internal class SampleAppQueryResolverTest @Autowired constructor(
             )
             val dto = SampleAppDetail("name", 1000, SampleStatus.OPEN).right()
             every { sampleAppQueryService.findByPrice(123) } returns dto
+            withMockUser(AppUserRole.USER)
 
             // when
             val response = webTestClient.query(query)

--- a/app/src/test/kotlin/com/santaclose/app/util/AppContextMocker.kt
+++ b/app/src/test/kotlin/com/santaclose/app/util/AppContextMocker.kt
@@ -1,0 +1,39 @@
+package com.santaclose.app.util
+
+import arrow.core.toOption
+import com.navercorp.fixturemonkey.kotlin.KFixtureMonkey
+import com.ninjasquad.springmockk.MockkBean
+import com.santaclose.app.auth.context.AppGraphQLContextFactory
+import com.santaclose.lib.entity.appUser.AppUser
+import com.santaclose.lib.entity.appUser.type.AppUserRole
+import io.mockk.coEvery
+import io.mockk.slot
+import net.jqwik.api.Arbitraries
+import org.springframework.web.reactive.function.server.ServerRequest
+
+internal abstract class AppContextMocker {
+    @MockkBean(relaxed = true)
+    private lateinit var appGraphQLContextFactory: AppGraphQLContextFactory
+
+    companion object {
+        private val sut = KFixtureMonkey.create()
+        private var idBuilder = Arbitraries.longs().between(0, 10000)
+    }
+
+    fun withMockUser(role: AppUserRole): AppUser {
+        val appUser = sut.giveMeBuilder(AppUser::class.java)
+            .set("role", role)
+            .sample()
+            .also { it.id = idBuilder.sample() }
+        val slot = slot<ServerRequest>()
+
+        coEvery { appGraphQLContextFactory.generateContextMap(capture(slot)) } answers {
+            mapOf(
+                "user" to appUser.toOption(),
+                "request" to slot.captured
+            )
+        }
+
+        return appUser
+    }
+}

--- a/app/src/test/kotlin/com/santaclose/app/util/AppContextMocker.kt
+++ b/app/src/test/kotlin/com/santaclose/app/util/AppContextMocker.kt
@@ -1,5 +1,6 @@
 package com.santaclose.app.util
 
+import arrow.core.None
 import arrow.core.toOption
 import com.navercorp.fixturemonkey.kotlin.KFixtureMonkey
 import com.ninjasquad.springmockk.MockkBean
@@ -35,5 +36,15 @@ internal abstract class AppContextMocker {
         }
 
         return appUser
+    }
+
+    fun withAnonymousUser() {
+        val slot = slot<ServerRequest>()
+        coEvery { appGraphQLContextFactory.generateContextMap(capture(slot)) } answers {
+            mapOf(
+                "user" to None,
+                "request" to slot.captured
+            )
+        }
     }
 }

--- a/app/src/test/kotlin/com/santaclose/app/util/WebTestClientExtensions.kt
+++ b/app/src/test/kotlin/com/santaclose/app/util/WebTestClientExtensions.kt
@@ -33,9 +33,12 @@ fun WebTestClient.ResponseSpec.success(query: String): WebTestClient.BodyContent
 fun WebTestClient.BodyContentSpec.verify(path: String, data: Any): WebTestClient.BodyContentSpec =
     this.jsonPath("$DATA_JSON_PATH.$path").isEqualTo(data)
 
-fun WebTestClient.ResponseSpec.verifyError(code: GraphqlErrorCode, message: String): WebTestClient.BodyContentSpec =
+fun WebTestClient.ResponseSpec.verifyError(
+    code: GraphqlErrorCode,
+    message: String? = null
+): WebTestClient.BodyContentSpec =
     this.expectBody()
         .jsonPath(DATA_JSON_PATH).doesNotExist()
         .jsonPath("$ERRORS_JSON_PATH.[0].extensions.code").isEqualTo(code.name)
-        .jsonPath("$ERRORS_JSON_PATH.[0].message").isEqualTo(message)
+        .apply { message?.let { jsonPath("$ERRORS_JSON_PATH.[0].message").isEqualTo(message) } }
         .jsonPath(EXTENSIONS_JSON_PATH).doesNotExist()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,5 +67,9 @@ subprojects {
 
     tasks.withType<Test> {
         useJUnitPlatform()
+        reports {
+            html.required.set(false)
+            junitXml.required.set(true)
+        }
     }
 }

--- a/lib/src/main/kotlin/com/santaclose/lib/entity/BaseEntity.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/entity/BaseEntity.kt
@@ -4,12 +4,12 @@ import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
+import javax.persistence.Column
 import javax.persistence.EntityListeners
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.MappedSuperclass
-import javax.validation.constraints.NotNull
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
@@ -19,10 +19,10 @@ abstract class BaseEntity {
     var id: Long = 0
 
     @CreatedDate
-    @field:NotNull
+    @Column(nullable = false)
     lateinit var createdAt: LocalDateTime
 
     @LastModifiedDate
-    @field:NotNull
+    @Column(nullable = false)
     lateinit var updatedAt: LocalDateTime
 }

--- a/lib/src/main/kotlin/com/santaclose/lib/entity/appUser/AppUser.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/entity/appUser/AppUser.kt
@@ -1,0 +1,24 @@
+package com.santaclose.lib.entity.appUser
+
+import com.santaclose.lib.entity.BaseEntity
+import com.santaclose.lib.entity.appUser.type.AppUserRole
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.validation.constraints.NotNull
+
+@Entity
+class AppUser(
+    @Column(length = 15)
+    @field:NotNull
+    var phoneNumber: String,
+
+    @field:NotNull
+    var socialId: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    @field:NotNull
+    var role: AppUserRole,
+) : BaseEntity()

--- a/lib/src/main/kotlin/com/santaclose/lib/entity/appUser/AppUser.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/entity/appUser/AppUser.kt
@@ -21,4 +21,6 @@ class AppUser(
     @Column(length = 10)
     @field:NotNull
     var role: AppUserRole,
-) : BaseEntity()
+) : BaseEntity() {
+    fun hasRole(role: AppUserRole) = this.role == role
+}

--- a/lib/src/main/kotlin/com/santaclose/lib/entity/appUser/type/AppUserRole.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/entity/appUser/type/AppUserRole.kt
@@ -1,6 +1,6 @@
 package com.santaclose.lib.entity.appUser.type
 
 enum class AppUserRole {
+    VIEWER,
     USER,
-    ADMIN,
 }

--- a/lib/src/main/kotlin/com/santaclose/lib/entity/appUser/type/AppUserRole.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/entity/appUser/type/AppUserRole.kt
@@ -1,0 +1,6 @@
+package com.santaclose.lib.entity.appUser.type
+
+enum class AppUserRole {
+    USER,
+    ADMIN,
+}

--- a/lib/src/main/kotlin/com/santaclose/lib/entity/sample/Sample.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/entity/sample/Sample.kt
@@ -15,7 +15,7 @@ class Sample(
     @field:NotNull
     var name: String,
 
-    @Positive
+    @field:Positive
     var price: Int,
 
     @Enumerated(EnumType.STRING)

--- a/lib/src/main/kotlin/com/santaclose/lib/web/error/GraphqlErrorExtentions.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/web/error/GraphqlErrorExtentions.kt
@@ -8,18 +8,20 @@ import javax.persistence.NoResultException
 enum class GraphqlErrorCode {
     NOT_FOUND,
     SERVER_ERROR,
+    UNAUTHORIZED,
 }
 
 fun <A> Either<Throwable, A>.getOrThrow(): A =
-    this.getOrHandle { throw it.toGraphQLError() }
+    this.getOrHandle { throw it.toGraphQLException() }
 
-fun Throwable.toGraphQLError(): Throwable = GraphqlErrorException.newErrorException()
+fun Throwable.toGraphQLException(): Throwable = GraphqlErrorException.newErrorException()
     .cause(this)
     .message(this.message)
     .extensions(
         mutableMapOf(
             "code" to when (this) {
                 is NoResultException -> GraphqlErrorCode.NOT_FOUND
+                is UnauthorizedException -> GraphqlErrorCode.UNAUTHORIZED
                 else -> GraphqlErrorCode.SERVER_ERROR
             }
         ) as Map<String, Any>?

--- a/lib/src/main/kotlin/com/santaclose/lib/web/error/UnauthorizedException.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/web/error/UnauthorizedException.kt
@@ -1,0 +1,3 @@
+package com.santaclose.lib.web.error
+
+class UnauthorizedException(message: String) : Throwable(message)


### PR DESCRIPTION
resolves #30

## 개요

권한이 있는 사용자만 특정 필드에 접근 가능하도록 구현한 작업입니다.

## 작업내용

- AppUser 엔티티 생성하였습니다.  필드는 임의로 설정한 것이고 이후 작업 때 확정하겠습니다.
- 로그인한 유저의 정보가 `GraphqlContext` 에 생성됩니다.
- `Auth` 어노테이션을 통해 특정 API 가 특정 권한을 가진 유저만 허용하도록 구현하였습니다.

## 리뷰 요청사항

- 본 PR에 아직 인증기능은 구현하지 않았고 다음 작업에 이어서 할 예정입니다.
- grphql 라이브러리 관련 설정코드가 많아서 리뷰하기 힘들거 같은 부분은 댓글로 남겨두었습니다.