### PR TITLE
[#43] 산 후기 등록 엔티티에 작성자 필드 추가

### DIFF
--- a/app/src/main/kotlin/com/santaclose/app/auth/context/AppGraphQLContextFactory.kt
+++ b/app/src/main/kotlin/com/santaclose/app/auth/context/AppGraphQLContextFactory.kt
@@ -12,7 +12,7 @@ class AppGraphQLContextFactory(
 ) : SpringGraphQLContextFactory<SpringGraphQLContext>() {
     override suspend fun generateContextMap(request: ServerRequest): Map<*, Any>? =
         mapOf(
-            "user" to serverRequestParser.parse(request),
+            "session" to serverRequestParser.parse(request),
             "request" to request,
         )
 

--- a/app/src/main/kotlin/com/santaclose/app/auth/context/DataFetchingEnvironmentExtension.kt
+++ b/app/src/main/kotlin/com/santaclose/app/auth/context/DataFetchingEnvironmentExtension.kt
@@ -2,6 +2,7 @@ package com.santaclose.app.auth.context
 
 import arrow.core.Option
 import arrow.core.getOrElse
+import com.santaclose.lib.web.error.UnauthorizedException
 import com.santaclose.lib.web.error.toGraphQLException
 import graphql.schema.DataFetchingEnvironment
 
@@ -10,7 +11,7 @@ fun DataFetchingEnvironment.session(): Option<AppSession> =
 
 fun DataFetchingEnvironment.user(): AppSession =
     this.session()
-        .getOrElse { throw Exception("사용자가 존재하지 않습니다").toGraphQLException() }
+        .getOrElse { throw UnauthorizedException("사용자가 존재하지 않습니다").toGraphQLException() }
 
 fun DataFetchingEnvironment.userId(): Long =
     this.user().id

--- a/app/src/main/kotlin/com/santaclose/app/auth/directive/AuthSchemaDirectiveWiring.kt
+++ b/app/src/main/kotlin/com/santaclose/app/auth/directive/AuthSchemaDirectiveWiring.kt
@@ -22,7 +22,7 @@ class AuthSchemaDirectiveWiring : KotlinSchemaDirectiveWiring {
         val originalDataFetcher = environment.getDataFetcher()
 
         DataFetcher { dfe ->
-            dfe.graphQlContext.get<Option<AppSession>>("user")
+            dfe.graphQlContext.get<Option<AppSession>>("session")
                 .filter { it.hasRole(role) }
                 .tapNone { throw UnauthorizedException("접근 권한이 없습니다").toGraphQLException() }
 

--- a/app/src/main/kotlin/com/santaclose/app/mountainReview/resolver/MountainReviewAppMutationResolver.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountainReview/resolver/MountainReviewAppMutationResolver.kt
@@ -1,9 +1,14 @@
 package com.santaclose.app.mountainReview.resolver
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.server.operations.Mutation
+import com.santaclose.app.auth.context.userId
+import com.santaclose.app.auth.directive.Auth
 import com.santaclose.app.mountainReview.resolver.dto.CreateMountainReviewAppInput
 import com.santaclose.app.mountainReview.service.MountainReviewAppMutationService
+import com.santaclose.lib.entity.appUser.type.AppUserRole
 import com.santaclose.lib.web.error.toGraphQLException
+import graphql.schema.DataFetchingEnvironment
 import org.springframework.stereotype.Component
 import org.springframework.validation.annotation.Validated
 import javax.validation.Valid
@@ -13,9 +18,11 @@ import javax.validation.Valid
 class MountainReviewAppMutationResolver(
     private val mountainAppMutationService: MountainReviewAppMutationService,
 ) : Mutation {
-    fun createMountainReview(@Valid input: CreateMountainReviewAppInput): Boolean {
+    @Auth(AppUserRole.USER)
+    @GraphQLDescription("산 리뷰 등록하기")
+    fun createMountainReview(@Valid input: CreateMountainReviewAppInput, dfe: DataFetchingEnvironment): Boolean {
         try {
-            return mountainAppMutationService.register(input).run { true }
+            return mountainAppMutationService.register(input, dfe.userId()).run { true }
         } catch (e: Throwable) {
             throw e.toGraphQLException()
         }

--- a/app/src/main/resources/graphql/schema.graphql
+++ b/app/src/main/resources/graphql/schema.graphql
@@ -36,7 +36,8 @@ type AppAuthInfo {
 }
 
 type Mutation {
-  createMountainReview(input: CreateMountainReviewAppInput!): Boolean!
+  "산 리뷰 등록하기"
+  createMountainReview(input: CreateMountainReviewAppInput!): Boolean! @auth(role : USER)
   "샘플 데이터"
   createSample(input: CreateSampleAppInput!): Boolean! @auth(role : USER)
   "로그인 및 회원가입"

--- a/app/src/test/kotlin/com/santaclose/app/auth/context/AppGraphQLContextFactoryTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/auth/context/AppGraphQLContextFactoryTest.kt
@@ -31,7 +31,7 @@ internal class AppGraphQLContextFactoryTest {
         // then
         result.shouldNotBeNull()
         result["request"] shouldBe request
-        result["user"]
+        result["session"]
             .shouldBeInstanceOf<Option<AppUser>>()
             .shouldBeSome(session)
     }

--- a/app/src/test/kotlin/com/santaclose/app/auth/directive/AuthSchemaDirectiveWiringTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/auth/directive/AuthSchemaDirectiveWiringTest.kt
@@ -54,7 +54,7 @@ internal class AuthSchemaDirectiveWiringTest {
 
             // then
             val fetchEnvMock = mockk<DataFetchingEnvironment>()
-            every { fetchEnvMock.graphQlContext.get<Option<AppSession>>("user") } returns None
+            every { fetchEnvMock.graphQlContext.get<Option<AppSession>>("session") } returns None
             shouldThrow<GraphqlErrorException> {
                 slot.captured.get(fetchEnvMock)
             }.apply {
@@ -78,7 +78,7 @@ internal class AuthSchemaDirectiveWiringTest {
             // then
             val fetchEnvMock = mockk<DataFetchingEnvironment>()
             val session = AppSession(11, AppUserRole.VIEWER)
-            every { fetchEnvMock.graphQlContext.get<Option<AppSession>>("user") } returns Some(session)
+            every { fetchEnvMock.graphQlContext.get<Option<AppSession>>("session") } returns Some(session)
 
             shouldThrow<GraphqlErrorException> {
                 slot.captured.get(fetchEnvMock)
@@ -103,7 +103,7 @@ internal class AuthSchemaDirectiveWiringTest {
             // then
             val fetchEnvMock = mockk<DataFetchingEnvironment>()
             val session = AppSession(11, AppUserRole.USER)
-            every { fetchEnvMock.graphQlContext.get<Option<AppSession>>("user") } returns Some(session)
+            every { fetchEnvMock.graphQlContext.get<Option<AppSession>>("session") } returns Some(session)
 
             shouldNotThrowAny { slot.captured.get(fetchEnvMock) }
         }

--- a/app/src/test/kotlin/com/santaclose/app/mountainReview/resolver/MountainReviewAppMutationResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/mountainReview/resolver/MountainReviewAppMutationResolverTest.kt
@@ -2,10 +2,12 @@ package com.santaclose.app.mountainReview.resolver
 
 import com.ninjasquad.springmockk.MockkBean
 import com.santaclose.app.mountainReview.service.MountainReviewAppMutationService
+import com.santaclose.app.util.AppContextMocker
 import com.santaclose.app.util.QueryInput
 import com.santaclose.app.util.query
 import com.santaclose.app.util.withError
 import com.santaclose.app.util.withSuccess
+import com.santaclose.lib.entity.appUser.type.AppUserRole
 import com.santaclose.lib.web.error.GraphqlErrorCode
 import io.mockk.every
 import io.mockk.justRun
@@ -23,7 +25,7 @@ internal class MountainReviewAppMutationResolverTest @Autowired constructor(
     private val webTestClient: WebTestClient,
     @MockkBean
     private val mountainReviewAppMutationService: MountainReviewAppMutationService,
-) {
+) : AppContextMocker() {
 
     @Nested
     inner class CreateMountainReview {
@@ -48,7 +50,8 @@ internal class MountainReviewAppMutationResolverTest @Autowired constructor(
                 |}
                 """.trimMargin()
             )
-            every { mountainReviewAppMutationService.register(any()) } throws NoResultException("no result")
+            every { mountainReviewAppMutationService.register(any(), any()) } throws NoResultException("no result")
+            withMockUser(AppUserRole.USER)
 
             // when
             val response = webTestClient.query(query)
@@ -78,7 +81,8 @@ internal class MountainReviewAppMutationResolverTest @Autowired constructor(
                 |}
                 """.trimMargin()
             )
-            justRun { mountainReviewAppMutationService.register(any()) }
+            justRun { mountainReviewAppMutationService.register(any(), 1) }
+            withMockUser(AppUserRole.USER)
 
             // when
             val response = webTestClient.query(query)

--- a/app/src/test/kotlin/com/santaclose/app/mountainReview/resolver/MountainReviewAppMutationResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/mountainReview/resolver/MountainReviewAppMutationResolverTest.kt
@@ -81,8 +81,8 @@ internal class MountainReviewAppMutationResolverTest @Autowired constructor(
                 |}
                 """.trimMargin()
             )
-            justRun { mountainReviewAppMutationService.register(any(), 1) }
-            withMockUser(AppUserRole.USER)
+            val session = withMockUser(AppUserRole.USER)
+            justRun { mountainReviewAppMutationService.register(any(), session.id) }
 
             // when
             val response = webTestClient.query(query)

--- a/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
@@ -41,7 +41,8 @@ internal class SampleAppQueryResolverTest @Autowired constructor(
                 |    price
                 |    status
                 |  }
-                |}""".trimMargin()
+                |}
+                """.trimMargin()
             )
             every { sampleAppQueryService.findByPrice(123) } returns NoResultException("no result").left()
             withAnonymousUser()
@@ -63,7 +64,8 @@ internal class SampleAppQueryResolverTest @Autowired constructor(
                 |    price
                 |    status
                 |  }
-                |}""".trimMargin()
+                |}
+                """.trimMargin()
             )
             every { sampleAppQueryService.findByPrice(123) } returns NoResultException("no result").left()
             withMockUser(AppUserRole.USER)
@@ -85,7 +87,8 @@ internal class SampleAppQueryResolverTest @Autowired constructor(
                 |    price
                 |    status
                 |  }
-                |}""".trimMargin()
+                |}
+                """.trimMargin()
             )
             val dto = SampleAppDetail("name", 1000, SampleStatus.OPEN).right()
             every { sampleAppQueryService.findByPrice(123) } returns dto

--- a/app/src/test/kotlin/com/santaclose/app/util/AppContextMocker.kt
+++ b/app/src/test/kotlin/com/santaclose/app/util/AppContextMocker.kt
@@ -28,7 +28,7 @@ internal abstract class AppContextMocker {
 
         coEvery { appGraphQLContextFactory.generateContextMap(capture(slot)) } answers {
             mapOf(
-                "user" to session.toOption(),
+                "session" to session.toOption(),
                 "request" to slot.captured
             )
         }
@@ -40,7 +40,7 @@ internal abstract class AppContextMocker {
         val slot = slot<ServerRequest>()
         coEvery { appGraphQLContextFactory.generateContextMap(capture(slot)) } answers {
             mapOf(
-                "user" to None,
+                "session" to None,
                 "request" to slot.captured
             )
         }

--- a/app/src/test/kotlin/com/santaclose/app/util/EntityManagerExtension.kt
+++ b/app/src/test/kotlin/com/santaclose/app/util/EntityManagerExtension.kt
@@ -1,0 +1,9 @@
+package com.santaclose.app.util
+
+import com.santaclose.lib.entity.appUser.AppUser
+import com.santaclose.lib.entity.appUser.type.AppUserRole
+import javax.persistence.EntityManager
+
+fun EntityManager.createAppUser(user: AppUser? = null): AppUser =
+    (user ?: AppUser("name", "email", "socialId", AppUserRole.USER))
+        .also { this.persist(it) }

--- a/lib/src/main/kotlin/com/santaclose/lib/entity/mountainReview/MountainReview.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/entity/mountainReview/MountainReview.kt
@@ -2,6 +2,7 @@ package com.santaclose.lib.entity.mountainReview
 
 import com.santaclose.lib.converter.StringListConverter
 import com.santaclose.lib.entity.BaseEntity
+import com.santaclose.lib.entity.appUser.AppUser
 import com.santaclose.lib.entity.mountain.Mountain
 import com.santaclose.lib.entity.mountainReview.type.MountainDifficulty
 import javax.persistence.Column
@@ -29,41 +30,39 @@ class MountainReview(
     @field:NotNull
     var content: String,
 
-    @ManyToOne(fetch = LAZY)
-    @field:NotNull
-    var mountain: Mountain,
-
     @Convert(converter = StringListConverter::class)
-    var images: List<String>,
+    var images: List<String> = emptyList(),
 
     @Enumerated(EnumType.STRING)
     @Column(length = 20)
     @field:NotNull
     var difficulty: MountainDifficulty,
 
-    // 추가한 사용자 id,
-    // 위치 id,
+    @ManyToOne(fetch = LAZY)
+    @field:NotNull
+    var mountain: Mountain,
+
+    @ManyToOne(fetch = LAZY)
+    @field:NotNull
+    var appUser: AppUser,
 ) : BaseEntity() {
     companion object {
         fun create(
             title: String,
-            scenery: Byte,
-            tree: Byte,
-            trail: Byte,
-            parking: Byte,
-            toilet: Byte,
-            traffic: Byte,
             content: String,
-            mountain: Mountain,
             images: List<String>,
+            rating: MountainRating,
             difficulty: MountainDifficulty,
+            mountain: Mountain,
+            appUser: AppUser,
         ): MountainReview = MountainReview(
             title,
-            MountainRating(scenery, tree, trail, parking, toilet, traffic),
+            rating,
             content,
-            mountain,
             images,
-            difficulty
+            difficulty,
+            mountain,
+            appUser,
         )
     }
 }


### PR DESCRIPTION
resolves #43 

## 개요

`MountainReview` 엔티티에 후기 작성자 필드를 추가

## 작업내용

- 후기 작성 api 는 로그인 사용자만 접근 가능하도록 수정
- 세션 관련 버그 수정

## 리뷰 요청사항

- `EntityManager` 에 `createAppUser` 확장 함수를 추가하였으니 참고 부탁드립니다!
     테스트 코드에서 임의의 유저를 디비에 넣고 싶을 때 사용할 수 있습니다.