### PR TITLE
[#68] graphql 테스트 관련 네이밍 변경

### DIFF
--- a/app/src/test/kotlin/com/santaclose/app/auth/resolver/AuthAppMutationResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/auth/resolver/AuthAppMutationResolverTest.kt
@@ -6,8 +6,8 @@ import com.ninjasquad.springmockk.MockkBean
 import com.santaclose.app.auth.context.AppSession
 import com.santaclose.app.auth.service.AuthAppService
 import com.santaclose.app.util.AppContextMocker
-import com.santaclose.app.util.QueryInput
-import com.santaclose.app.util.query
+import com.santaclose.app.util.GraphqlBody
+import com.santaclose.app.util.gqlRequest
 import com.santaclose.app.util.withError
 import com.santaclose.app.util.withSuccess
 import com.santaclose.lib.entity.appUser.type.AppUserRole
@@ -36,7 +36,7 @@ constructor(
       // given
       val code = "code"
       val query =
-        QueryInput(
+        GraphqlBody(
           """mutation {
             |  signIn(input: {code: "$code", type: KAKAO}) {
             |    accessToken
@@ -47,7 +47,7 @@ constructor(
       coEvery { authAppService.signIn(code) } returns Exception("error").left()
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withError(GraphqlErrorCode.SERVER_ERROR, "error")
@@ -58,7 +58,7 @@ constructor(
       // given
       val code = "code"
       val query =
-        QueryInput(
+        GraphqlBody(
           """mutation {
             |  signIn(input: {code: "$code", type: KAKAO}) {
             |    accessToken
@@ -69,7 +69,7 @@ constructor(
       coEvery { authAppService.signIn(code) } returns AppSession(123, AppUserRole.USER).right()
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withSuccess("signIn") {

--- a/app/src/test/kotlin/com/santaclose/app/category/resolver/CategoryAppQueryResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/category/resolver/CategoryAppQueryResolverTest.kt
@@ -1,8 +1,8 @@
 package com.santaclose.app.category.resolver
 
 import com.santaclose.app.util.AppContextMocker
-import com.santaclose.app.util.QueryInput
-import com.santaclose.app.util.query
+import com.santaclose.app.util.GraphqlBody
+import com.santaclose.app.util.gqlRequest
 import com.santaclose.app.util.withSuccess
 import com.santaclose.lib.entity.appUser.type.AppUserRole
 import java.io.File
@@ -27,7 +27,7 @@ constructor(
     fun `요청한 category 정보를 file 에 저장한다`() {
       // given
       val query =
-        QueryInput(
+        GraphqlBody(
           """query {
             |  categories {
             |    mountainDifficulty {
@@ -41,7 +41,7 @@ constructor(
       withMockUser(AppUserRole.USER)
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withSuccess("categories") {

--- a/app/src/test/kotlin/com/santaclose/app/mountainReview/resolver/MountainReviewAppMutationResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/mountainReview/resolver/MountainReviewAppMutationResolverTest.kt
@@ -3,8 +3,8 @@ package com.santaclose.app.mountainReview.resolver
 import com.ninjasquad.springmockk.MockkBean
 import com.santaclose.app.mountainReview.service.MountainReviewAppMutationService
 import com.santaclose.app.util.AppContextMocker
-import com.santaclose.app.util.QueryInput
-import com.santaclose.app.util.query
+import com.santaclose.app.util.GraphqlBody
+import com.santaclose.app.util.gqlRequest
 import com.santaclose.app.util.withError
 import com.santaclose.app.util.withSuccess
 import com.santaclose.lib.entity.appUser.type.AppUserRole
@@ -34,7 +34,7 @@ constructor(
     fun `mountainId 가 유효하지 않으면 NOT FOUND 를 반환한다`() {
       // given
       val query =
-        QueryInput(
+        GraphqlBody(
           """mutation {
             |  createMountainReview(input: { 
             |    mountainId: "1" 
@@ -57,7 +57,7 @@ constructor(
       withMockUser(AppUserRole.USER)
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withError(GraphqlErrorCode.NOT_FOUND, "no result")
@@ -67,7 +67,7 @@ constructor(
     fun `정상적으로 생성한다`() {
       // given
       val query =
-        QueryInput(
+        GraphqlBody(
           """mutation {
             |  createMountainReview(input: { 
             |    mountainId: "1" 
@@ -89,7 +89,7 @@ constructor(
       justRun { mountainReviewAppMutationService.register(any(), session.id) }
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withSuccess("createMountainReview")

--- a/app/src/test/kotlin/com/santaclose/app/restaurantReview/resolver/RestaurantReviewAppMutationResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/restaurantReview/resolver/RestaurantReviewAppMutationResolverTest.kt
@@ -3,8 +3,8 @@ package com.santaclose.app.restaurantReview.resolver
 import com.ninjasquad.springmockk.MockkBean
 import com.santaclose.app.restaurantReview.service.RestaurantReviewAppMutationService
 import com.santaclose.app.util.AppContextMocker
-import com.santaclose.app.util.QueryInput
-import com.santaclose.app.util.query
+import com.santaclose.app.util.GraphqlBody
+import com.santaclose.app.util.gqlRequest
 import com.santaclose.app.util.withError
 import com.santaclose.app.util.withSuccess
 import com.santaclose.lib.entity.appUser.type.AppUserRole
@@ -33,7 +33,7 @@ constructor(
     fun `에리가 발생하면 에러를 반환한다`() {
       // given
       val query =
-        QueryInput(
+        GraphqlBody(
           """mutation {
             |  createRestaurantReview(input: { 
             |    restaurantId: "1"
@@ -58,7 +58,7 @@ constructor(
       withMockUser(AppUserRole.USER)
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withError(GraphqlErrorCode.NOT_FOUND, "no result")
@@ -68,7 +68,7 @@ constructor(
     fun `정상적으로 생성된다`() {
       // given
       val query =
-        QueryInput(
+        GraphqlBody(
           """mutation {
             |  createRestaurantReview(input: { 
             |    restaurantId: "1"
@@ -92,7 +92,7 @@ constructor(
       withMockUser(AppUserRole.USER)
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withSuccess("createRestaurantReview")

--- a/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/sample/resolver/SampleAppQueryResolverTest.kt
@@ -6,8 +6,8 @@ import com.ninjasquad.springmockk.MockkBean
 import com.santaclose.app.sample.resolver.dto.SampleAppDetail
 import com.santaclose.app.sample.service.SampleAppQueryService
 import com.santaclose.app.util.AppContextMocker
-import com.santaclose.app.util.QueryInput
-import com.santaclose.app.util.query
+import com.santaclose.app.util.GraphqlBody
+import com.santaclose.app.util.gqlRequest
 import com.santaclose.app.util.withError
 import com.santaclose.app.util.withSuccess
 import com.santaclose.lib.entity.appUser.type.AppUserRole
@@ -36,7 +36,7 @@ constructor(
     fun `권한없는 유저가 요청 시 에러가 발생한다`() {
       // given
       val query =
-        QueryInput(
+        GraphqlBody(
           """query {
             |  sample(input: {price: 123}) {
             |    name
@@ -50,7 +50,7 @@ constructor(
       withAnonymousUser()
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withError(GraphqlErrorCode.UNAUTHORIZED, "접근 권한이 없습니다")
@@ -60,7 +60,7 @@ constructor(
     fun `데이터가 없는 경우 에러가 발생한다`() {
       // given
       val query =
-        QueryInput(
+        GraphqlBody(
           """query {
             |  sample(input: {price: 123}) {
             |    name
@@ -74,7 +74,7 @@ constructor(
       withMockUser(AppUserRole.USER)
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withError(GraphqlErrorCode.NOT_FOUND, "no result")
@@ -84,7 +84,7 @@ constructor(
     fun `데이터가 있는 경우 sample 을 가져온다`() {
       // given
       val query =
-        QueryInput(
+        GraphqlBody(
           """query {
             |  sample(input: {price: 123}) {
             |    name
@@ -99,7 +99,7 @@ constructor(
       withMockUser(AppUserRole.USER)
 
       // when
-      val response = webTestClient.query(query)
+      val response = webTestClient.gqlRequest(query)
 
       // then
       response.withSuccess("sample") {

--- a/app/src/test/kotlin/com/santaclose/app/util/WebTestClientExtensions.kt
+++ b/app/src/test/kotlin/com/santaclose/app/util/WebTestClientExtensions.kt
@@ -14,14 +14,14 @@ const val DATA_JSON_PATH = "$.data"
 const val ERRORS_JSON_PATH = "$.errors"
 const val EXTENSIONS_JSON_PATH = "$.extensions"
 
-@JvmInline value class QueryInput(@Language("GraphQL") val query: String)
+@JvmInline value class GraphqlBody(@Language("GraphQL") val body: String)
 
-fun WebTestClient.query(queryInput: QueryInput): WebTestClient.ResponseSpec =
+fun WebTestClient.gqlRequest(queryInput: GraphqlBody): WebTestClient.ResponseSpec =
   this.post()
     .uri(GRAPHQL_ENDPOINT)
     .accept(APPLICATION_JSON)
     .contentType(GRAPHQL_MEDIA_TYPE)
-    .bodyValue(queryInput.query)
+    .bodyValue(queryInput.body)
     .exchange()
     .expectStatus()
     .isOk


### PR DESCRIPTION
resolves #68

## 작업내용

아래 테스트 관련 항목 이름 변경

- webTestClient.query -> webTestClient.gqlRequest 
- QueryInput -> GraphqlBody
