### PR TITLE
[#80] bom 을 사용한 의존성 패키지 도입

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -13,9 +13,9 @@ dependencies {
   runtimeOnly("com.h2database:h2")
   runtimeOnly("mysql:mysql-connector-java")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
-  testImplementation("org.testcontainers:testcontainers:1.16.3")
-  testImplementation("org.testcontainers:junit-jupiter:1.16.3")
-  testImplementation("org.testcontainers:localstack:1.16.3")
+  testImplementation(platform("org.testcontainers:testcontainers-bom:1.17.1"))
+  testImplementation("org.testcontainers:junit-jupiter")
+  testImplementation("org.testcontainers:localstack")
 }
 
 allOpen {

--- a/lib/src/main/kotlin/com/santaclose/lib/s3Upload/S3Uploader.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/s3Upload/S3Uploader.kt
@@ -1,11 +1,11 @@
 package com.santaclose.lib.s3Upload
 
 import arrow.core.Either.Companion.catch
-import aws.sdk.kotlin.runtime.auth.credentials.Credentials
 import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import aws.sdk.kotlin.runtime.endpoint.AwsEndpoint
 import aws.sdk.kotlin.runtime.endpoint.StaticEndpointResolver
 import aws.sdk.kotlin.services.s3.S3Client
+import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.content.ByteStream
 
 class S3Uploader private constructor(private val s3Client: S3Client) {

--- a/lib/src/test/kotlin/com/santaclose/lib/s3Upload/S3UploaderTest.kt
+++ b/lib/src/test/kotlin/com/santaclose/lib/s3Upload/S3UploaderTest.kt
@@ -1,11 +1,11 @@
 package com.santaclose.lib.s3Upload
 
-import aws.sdk.kotlin.runtime.auth.credentials.Credentials
 import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import aws.sdk.kotlin.runtime.endpoint.AwsEndpoint
 import aws.sdk.kotlin.runtime.endpoint.StaticEndpointResolver
 import aws.sdk.kotlin.services.s3.S3Client
 import aws.sdk.kotlin.services.s3.model.GetObjectRequest
+import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.content.ByteStream
 import io.kotest.assertions.throwables.shouldNotThrow
 import kotlinx.coroutines.runBlocking


### PR DESCRIPTION
resolves #80 

## 작업내용

Testcontainer 의 연관된 패키지들의 버전정보를 하나로 관리할 수 있게하는 bom 패키지를 설치하였습니다.

## 리뷰 참고사항

aws.sdk.kotlin.runtime.auth.credentials.Credentials 패키지가 gradle Refresh 한 이후로 다른 패키지로 변경되어 같이 작업하였습니다.