### PR TITLE
[#82] 산과 연관된 식당 좌표를 가져오는 api 구현

### DIFF
--- a/app/src/main/kotlin/com/santaclose/app/auth/service/AuthAppService.kt
+++ b/app/src/main/kotlin/com/santaclose/app/auth/service/AuthAppService.kt
@@ -2,7 +2,7 @@ package com.santaclose.app.auth.service
 
 import arrow.core.Either
 import arrow.core.Either.Companion.catch
-import arrow.core.computations.either
+import arrow.core.continuations.either
 import com.santaclose.app.appUser.repository.AppUserAppQueryRepository
 import com.santaclose.app.appUser.repository.AppUserAppRepository
 import com.santaclose.app.auth.context.AppSession

--- a/app/src/main/kotlin/com/santaclose/app/location/service/LocationAppQueryService.kt
+++ b/app/src/main/kotlin/com/santaclose/app/location/service/LocationAppQueryService.kt
@@ -25,10 +25,9 @@ class LocationAppQueryService(
     }
 
     return runBlocking {
-      val service = this@LocationAppQueryService
       val ids = locations.map { it.id }
-      val mountains = async { service.mountainAppRepository.findByLocationIdIn(ids) }
-      val restaurants = async { service.restaurantAppRepository.findByLocationIdIn(ids) }
+      val mountains = async { mountainAppRepository.findByLocationIdIn(ids) }
+      val restaurants = async { restaurantAppRepository.findByLocationIdIn(ids) }
 
       val findPoint = { id: Long ->
         locations.find { it.id == id }?.point ?: throw Exception("should have location: id=$id")

--- a/app/src/main/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolver.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolver.kt
@@ -1,21 +1,27 @@
 package com.santaclose.app.mountain.resolver
 
+import arrow.core.Either.Companion.catch
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.generator.scalars.ID
 import com.expediagroup.graphql.server.operations.Query
 import com.santaclose.app.auth.directive.Auth
 import com.santaclose.app.mountain.resolver.dto.MountainDetailAppInput
+import com.santaclose.app.mountain.resolver.dto.MountainSummary
 import com.santaclose.app.mountain.service.MountainAppQueryService
 import com.santaclose.lib.entity.appUser.type.AppUserRole
 import com.santaclose.lib.logger.logger
+import com.santaclose.lib.web.error.getOrThrow
 import com.santaclose.lib.web.error.toGraphQLException
+import com.santaclose.lib.web.toLong
 import javax.validation.Valid
 import org.springframework.stereotype.Component
 import org.springframework.validation.annotation.Validated
 
 @Component
 @Validated
-class MountainAppQueryResolver(private val mountainAppQueryService: MountainAppQueryService) :
-  Query {
+class MountainAppQueryResolver(
+  private val mountainAppQueryService: MountainAppQueryService,
+) : Query {
   val logger = logger()
 
   @Auth(AppUserRole.USER)
@@ -31,4 +37,10 @@ class MountainAppQueryResolver(private val mountainAppQueryService: MountainAppQ
       throw e.toGraphQLException()
     }
   }
+
+  @Auth(AppUserRole.USER)
+  @GraphQLDescription("산 요약 정보")
+  suspend fun mountainSummary(id: ID): MountainSummary =
+    catch { mountainAppQueryService.findOneSummary(id.toLong()).let(MountainSummary::by) }
+      .getOrThrow()
 }

--- a/app/src/main/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolver.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolver.kt
@@ -40,7 +40,7 @@ class MountainAppQueryResolver(
 
   @Auth(AppUserRole.USER)
   @GraphQLDescription("산 요약 정보")
-  suspend fun mountainSummary(id: ID): MountainAppSummary =
+  fun mountainSummary(id: ID): MountainAppSummary =
     catch { mountainAppQueryService.findOneSummary(id.toLong()).let(MountainAppSummary::by) }
       .tapLeft { logger.error(it.message, it) }
       .getOrThrow()

--- a/app/src/main/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolver.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolver.kt
@@ -5,8 +5,8 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.scalars.ID
 import com.expediagroup.graphql.server.operations.Query
 import com.santaclose.app.auth.directive.Auth
+import com.santaclose.app.mountain.resolver.dto.MountainAppSummary
 import com.santaclose.app.mountain.resolver.dto.MountainDetailAppInput
-import com.santaclose.app.mountain.resolver.dto.MountainSummary
 import com.santaclose.app.mountain.service.MountainAppQueryService
 import com.santaclose.lib.entity.appUser.type.AppUserRole
 import com.santaclose.lib.logger.logger
@@ -40,7 +40,8 @@ class MountainAppQueryResolver(
 
   @Auth(AppUserRole.USER)
   @GraphQLDescription("산 요약 정보")
-  suspend fun mountainSummary(id: ID): MountainSummary =
-    catch { mountainAppQueryService.findOneSummary(id.toLong()).let(MountainSummary::by) }
+  suspend fun mountainSummary(id: ID): MountainAppSummary =
+    catch { mountainAppQueryService.findOneSummary(id.toLong()).let(MountainAppSummary::by) }
+      .tapLeft { logger.error(it.message, it) }
       .getOrThrow()
 }

--- a/app/src/main/kotlin/com/santaclose/app/mountain/resolver/dto/MountainAppSummary.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountain/resolver/dto/MountainAppSummary.kt
@@ -4,17 +4,23 @@ import com.expediagroup.graphql.generator.scalars.ID
 import com.santaclose.app.mountain.service.dto.MountainSummaryDto
 import com.santaclose.lib.web.toID
 
-data class MountainSummary(
+data class MountainAppSummary(
   val id: ID,
   val imageUrl: String,
   val address: String,
+  val rating: Double,
+  val reviewCount: Int,
+  val locations: List<RestaurantAppCoordinate>
 ) {
   companion object {
-    fun by(dto: MountainSummaryDto): MountainSummary =
-      MountainSummary(
+    fun by(dto: MountainSummaryDto): MountainAppSummary =
+      MountainAppSummary(
         id = dto.mountain.id.toID(),
         imageUrl = dto.mountain.images.first(),
         address = dto.mountain.location.address,
+        rating = dto.mountainRating.average,
+        reviewCount = dto.mountainRating.totalCount.toInt(),
+        locations = dto.restaurantLocations.map(RestaurantAppCoordinate::by)
       )
   }
 }

--- a/app/src/main/kotlin/com/santaclose/app/mountain/resolver/dto/MountainSummary.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountain/resolver/dto/MountainSummary.kt
@@ -1,0 +1,20 @@
+package com.santaclose.app.mountain.resolver.dto
+
+import com.expediagroup.graphql.generator.scalars.ID
+import com.santaclose.app.mountain.service.dto.MountainSummaryDto
+import com.santaclose.lib.web.toID
+
+data class MountainSummary(
+  val id: ID,
+  val imageUrl: String,
+  val address: String,
+) {
+  companion object {
+    fun by(dto: MountainSummaryDto): MountainSummary =
+      MountainSummary(
+        id = dto.mountain.id.toID(),
+        imageUrl = dto.mountain.images.first(),
+        address = dto.mountain.location.address,
+      )
+  }
+}

--- a/app/src/main/kotlin/com/santaclose/app/mountain/resolver/dto/RestaurantAppCoordinate.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountain/resolver/dto/RestaurantAppCoordinate.kt
@@ -1,0 +1,20 @@
+package com.santaclose.app.mountain.resolver.dto
+
+import com.expediagroup.graphql.generator.scalars.ID
+import com.santaclose.app.location.resolver.dto.AppCoordinate
+import com.santaclose.app.restaurant.repository.dto.RestaurantLocationDto
+import com.santaclose.lib.web.toID
+
+data class RestaurantAppCoordinate(
+  val id: ID,
+  val coordinate: AppCoordinate,
+) {
+
+  companion object {
+    fun by(dto: RestaurantLocationDto): RestaurantAppCoordinate =
+      RestaurantAppCoordinate(
+        dto.id.toID(),
+        dto.point.coordinate.run { AppCoordinate(longitude = x, latitude = y) }
+      )
+  }
+}

--- a/app/src/main/kotlin/com/santaclose/app/mountain/service/MountainAppQueryService.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountain/service/MountainAppQueryService.kt
@@ -3,14 +3,19 @@ package com.santaclose.app.mountain.service
 import com.expediagroup.graphql.generator.scalars.ID
 import com.santaclose.app.mountain.repository.MountainAppQueryRepository
 import com.santaclose.app.mountain.resolver.dto.MountainAppDetail
+import com.santaclose.app.mountain.service.dto.MountainSummaryDto
 import com.santaclose.app.mountainReview.repository.MountainReviewAppQueryRepository
+import com.santaclose.app.restaurant.repository.RestaurantAppQueryRepository
 import com.santaclose.lib.web.toLong
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import org.springframework.stereotype.Service
 
 @Service
 class MountainAppQueryService(
   private val mountainAppQueryRepository: MountainAppQueryRepository,
   private val mountainReviewAppQueryRepository: MountainReviewAppQueryRepository,
+  private val restaurantAppQueryRepository: RestaurantAppQueryRepository,
 ) {
   fun findDetail(id: ID): MountainAppDetail {
     val mountain = mountainAppQueryRepository.findOneWithLocation(id.toLong())
@@ -25,5 +30,13 @@ class MountainAppQueryService(
       mountainReviews,
       mountainRatingAverageDto
     )
+  }
+
+  suspend fun findOneSummary(mountainId: Long): MountainSummaryDto = coroutineScope {
+    val mountain = async { mountainAppQueryRepository.findOneWithLocation(mountainId) }
+    val locations = async { restaurantAppQueryRepository.findLocationByMountain(mountainId) }
+    val ratings = async { mountainReviewAppQueryRepository.findMountainRatingAverages(mountainId) }
+
+    MountainSummaryDto(mountain.await(), locations.await(), ratings.await())
   }
 }

--- a/app/src/main/kotlin/com/santaclose/app/mountain/service/MountainAppQueryService.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountain/service/MountainAppQueryService.kt
@@ -8,7 +8,7 @@ import com.santaclose.app.mountainReview.repository.MountainReviewAppQueryReposi
 import com.santaclose.app.restaurant.repository.RestaurantAppQueryRepository
 import com.santaclose.lib.web.toLong
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Service
 
 @Service
@@ -32,7 +32,7 @@ class MountainAppQueryService(
     )
   }
 
-  suspend fun findOneSummary(mountainId: Long): MountainSummaryDto = coroutineScope {
+  fun findOneSummary(mountainId: Long): MountainSummaryDto = runBlocking {
     val mountain = async { mountainAppQueryRepository.findOneWithLocation(mountainId) }
     val locations = async { restaurantAppQueryRepository.findLocationByMountain(mountainId) }
     val ratings = async { mountainReviewAppQueryRepository.findMountainRatingAverages(mountainId) }

--- a/app/src/main/kotlin/com/santaclose/app/mountain/service/dto/MountainSummaryDto.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountain/service/dto/MountainSummaryDto.kt
@@ -1,0 +1,11 @@
+package com.santaclose.app.mountain.service.dto
+
+import com.santaclose.app.mountainReview.repository.dto.MountainRatingAverageDto
+import com.santaclose.app.restaurant.repository.dto.RestaurantLocationDto
+import com.santaclose.lib.entity.mountain.Mountain
+
+data class MountainSummaryDto(
+  val mountain: Mountain,
+  val restaurantLocations: List<RestaurantLocationDto>,
+  val mountainRating: MountainRatingAverageDto,
+)

--- a/app/src/main/kotlin/com/santaclose/app/mountainReview/repository/MountainReviewAppQueryRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountainReview/repository/MountainReviewAppQueryRepositoryImpl.kt
@@ -32,20 +32,26 @@ class MountainReviewAppQueryRepositoryImpl(
     }
 
   override fun findMountainRatingAverages(mountainId: Long): MountainRatingAverageDto =
-    springDataQueryFactory.singleQuery {
-      val mountainReview: EntitySpec<MountainReview> = entity(MountainReview::class)
-      selectMulti(
-        avg(MountainRating::scenery),
-        avg(MountainRating::tree),
-        avg(MountainRating::trail),
-        avg(MountainRating::parking),
-        avg(MountainRating::toilet),
-        avg(MountainRating::traffic),
-        count(col(MountainReview::id)),
-      )
-      associate(MountainReview::class, MountainRating::class, on(MountainReview::rating))
-      from(mountainReview)
-      join(MountainReview::mountain, JoinType.INNER)
-      where(col(Mountain::id).equal(mountainId))
+    try {
+      springDataQueryFactory
+        .selectQuery<MountainRatingAverageDto> {
+          val mountainReview: EntitySpec<MountainReview> = entity(MountainReview::class)
+          selectMulti(
+            avg(MountainRating::scenery),
+            avg(MountainRating::tree),
+            avg(MountainRating::trail),
+            avg(MountainRating::parking),
+            avg(MountainRating::toilet),
+            avg(MountainRating::traffic),
+            count(col(MountainReview::id)),
+          )
+          associate(MountainReview::class, MountainRating::class, on(MountainReview::rating))
+          from(mountainReview)
+          join(MountainReview::mountain, JoinType.INNER)
+          where(col(Mountain::id).equal(mountainId))
+        }
+        .singleResult
+    } catch (e: IllegalArgumentException) {
+      MountainRatingAverageDto.empty
     }
 }

--- a/app/src/main/kotlin/com/santaclose/app/mountainReview/repository/MountainReviewAppQueryRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountainReview/repository/MountainReviewAppQueryRepositoryImpl.kt
@@ -7,7 +7,7 @@ import com.linecorp.kotlinjdsl.querydsl.from.fetch
 import com.linecorp.kotlinjdsl.querydsl.from.join
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
 import com.linecorp.kotlinjdsl.spring.data.listQuery
-import com.linecorp.kotlinjdsl.spring.data.singleQuery
+import com.linecorp.kotlinjdsl.spring.data.selectQuery
 import com.santaclose.app.mountainReview.repository.dto.MountainRatingAverageDto
 import com.santaclose.lib.entity.mountain.Mountain
 import com.santaclose.lib.entity.mountainReview.MountainRating

--- a/app/src/main/kotlin/com/santaclose/app/mountainReview/repository/dto/MountainRatingAverageDto.kt
+++ b/app/src/main/kotlin/com/santaclose/app/mountainReview/repository/dto/MountainRatingAverageDto.kt
@@ -11,4 +11,8 @@ data class MountainRatingAverageDto(
 ) {
   val average: Double
     get() = (scenery + tree + trail + parking + toilet + traffic) / 6
+
+  companion object {
+    val empty = MountainRatingAverageDto(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0)
+  }
 }

--- a/app/src/main/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepository.kt
+++ b/app/src/main/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepository.kt
@@ -1,7 +1,9 @@
 package com.santaclose.app.restaurant.repository
 
 import com.santaclose.lib.entity.restaurant.Restaurant
+import com.santaclose.app.restaurant.repository.dto.RestaurantLocationDto
 
 interface RestaurantAppQueryRepository {
+  fun findLocationByMountain(mountainId: Long): List<RestaurantLocationDto>
   fun findOneWithLocation(id: Long): Restaurant
 }

--- a/app/src/main/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepository.kt
+++ b/app/src/main/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepository.kt
@@ -1,7 +1,7 @@
 package com.santaclose.app.restaurant.repository
 
-import com.santaclose.lib.entity.restaurant.Restaurant
 import com.santaclose.app.restaurant.repository.dto.RestaurantLocationDto
+import com.santaclose.lib.entity.restaurant.Restaurant
 
 interface RestaurantAppQueryRepository {
   fun findLocationByMountain(mountainId: Long): List<RestaurantLocationDto>

--- a/app/src/main/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImpl.kt
@@ -1,9 +1,13 @@
 package com.santaclose.app.restaurant.repository
 
 import com.linecorp.kotlinjdsl.querydsl.expression.col
-import com.linecorp.kotlinjdsl.querydsl.from.fetch
+import com.linecorp.kotlinjdsl.querydsl.from.join
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
-import com.linecorp.kotlinjdsl.spring.data.singleQuery
+import com.linecorp.kotlinjdsl.spring.data.listQuery
+import com.santaclose.app.restaurant.repository.dto.RestaurantLocationDto
+import com.santaclose.lib.entity.location.Location
+import com.santaclose.lib.entity.mountain.Mountain
+import com.santaclose.lib.entity.mountainRestaurant.MountainRestaurant
 import com.santaclose.lib.entity.restaurant.Restaurant
 import javax.persistence.criteria.JoinType
 import org.springframework.stereotype.Repository
@@ -11,11 +15,22 @@ import org.springframework.stereotype.Repository
 @Repository
 class RestaurantAppQueryRepositoryImpl(private val springDataQueryFactory: SpringDataQueryFactory) :
   RestaurantAppQueryRepository {
+
   override fun findOneWithLocation(id: Long): Restaurant =
     springDataQueryFactory.singleQuery {
       select(entity(Restaurant::class))
       from(Restaurant::class)
-      fetch(Restaurant::location, JoinType.INNER)
       where(col(Restaurant::id).equal(id))
+      fetch(Restaurant::location, JoinType.INNER)
+    }
+
+  override fun findLocationByMountain(mountainId: Long): List<RestaurantLocationDto> =
+    this.springDataQueryFactory.listQuery {
+      selectMulti(col(Restaurant::id), col(Location::point))
+      from(Mountain::class)
+      join(Mountain::mountainRestaurant, JoinType.INNER)
+      join(MountainRestaurant::restaurant, JoinType.INNER)
+      where(col(Mountain::id).equal(mountainId))
+      join(Restaurant::location, JoinType.INNER)
     }
 }

--- a/app/src/main/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImpl.kt
@@ -1,9 +1,11 @@
 package com.santaclose.app.restaurant.repository
 
 import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.querydsl.from.fetch
 import com.linecorp.kotlinjdsl.querydsl.from.join
 import com.linecorp.kotlinjdsl.spring.data.SpringDataQueryFactory
 import com.linecorp.kotlinjdsl.spring.data.listQuery
+import com.linecorp.kotlinjdsl.spring.data.singleQuery
 import com.santaclose.app.restaurant.repository.dto.RestaurantLocationDto
 import com.santaclose.lib.entity.location.Location
 import com.santaclose.lib.entity.mountain.Mountain

--- a/app/src/main/kotlin/com/santaclose/app/restaurant/repository/dto/RestaurantLocationDto.kt
+++ b/app/src/main/kotlin/com/santaclose/app/restaurant/repository/dto/RestaurantLocationDto.kt
@@ -1,0 +1,5 @@
+package com.santaclose.app.restaurant.repository.dto
+
+import org.locationtech.jts.geom.Geometry
+
+data class RestaurantLocationDto(val id: Long, val point: Geometry)

--- a/app/src/main/kotlin/com/santaclose/app/restaurant/repository/dto/RestaurantLocationDto.kt
+++ b/app/src/main/kotlin/com/santaclose/app/restaurant/repository/dto/RestaurantLocationDto.kt
@@ -2,4 +2,7 @@ package com.santaclose.app.restaurant.repository.dto
 
 import org.locationtech.jts.geom.Geometry
 
-data class RestaurantLocationDto(val id: Long, val point: Geometry)
+data class RestaurantLocationDto(
+  val id: Long,
+  val point: Geometry,
+)

--- a/app/src/main/resources/graphql/schema.graphql
+++ b/app/src/main/resources/graphql/schema.graphql
@@ -103,12 +103,17 @@ type Query {
   locations(input: LocationAppInput!): [AppLocation!]! @auth(role : USER)
   "산 상세 조회"
   mountainDetail(input: MountainDetailAppInput!): Boolean! @auth(role : USER)
-  "맛집 상세 조회"
-  restaurantDetail(id: ID!): RestaurantAppDetail! @auth(role : USER)
   "산 요약 정보"
   mountainSummary(id: ID!): MountainAppSummary! @auth(role : USER)
+  "맛집 상세 조회"
+  restaurantDetail(id: ID!): RestaurantAppDetail! @auth(role : USER)
   "샘플 데이터"
   sample(input: SampleAppItemInput!): SampleAppDetail! @auth(role : USER)
+}
+
+type RestaurantAppCoordinate {
+  coordinate: AppCoordinate!
+  id: ID!
 }
 
 type RestaurantAppDetail {
@@ -118,11 +123,6 @@ type RestaurantAppDetail {
   name: String!
   restaurantRatingAverage: RestaurantRatingAverage!
   restaurantReviews: [LatestRestaurantReview!]!
-}
-
-type RestaurantAppCoordinate {
-  coordinate: AppCoordinate!
-  id: ID!
 }
 
 type RestaurantAppLocation implements AppLocation {

--- a/app/src/main/resources/graphql/schema.graphql
+++ b/app/src/main/resources/graphql/schema.graphql
@@ -67,15 +67,18 @@ type MountainAppLocation implements AppLocation {
   type: LocationType!
 }
 
-type MountainDifficultyCategory {
-  code: MountainDifficulty!
-  name: String!
-}
-
-type MountainSummary {
+type MountainAppSummary {
   address: String!
   id: ID!
   imageUrl: String!
+  locations: [RestaurantAppCoordinate!]!
+  rating: Float!
+  reviewCount: Int!
+}
+
+type MountainDifficultyCategory {
+  code: MountainDifficulty!
+  name: String!
 }
 
 type Mutation {
@@ -103,7 +106,7 @@ type Query {
   "맛집 상세 조회"
   restaurantDetail(id: ID!): RestaurantAppDetail! @auth(role : USER)
   "산 요약 정보"
-  mountainSummary(id: ID!): MountainSummary! @auth(role : USER)
+  mountainSummary(id: ID!): MountainAppSummary! @auth(role : USER)
   "샘플 데이터"
   sample(input: SampleAppItemInput!): SampleAppDetail! @auth(role : USER)
 }
@@ -115,6 +118,11 @@ type RestaurantAppDetail {
   name: String!
   restaurantRatingAverage: RestaurantRatingAverage!
   restaurantReviews: [LatestRestaurantReview!]!
+}
+
+type RestaurantAppCoordinate {
+  coordinate: AppCoordinate!
+  id: ID!
 }
 
 type RestaurantAppLocation implements AppLocation {

--- a/app/src/main/resources/graphql/schema.graphql
+++ b/app/src/main/resources/graphql/schema.graphql
@@ -72,6 +72,12 @@ type MountainDifficultyCategory {
   name: String!
 }
 
+type MountainSummary {
+  address: String!
+  id: ID!
+  imageUrl: String!
+}
+
 type Mutation {
   "산 리뷰 등록하기"
   createMountainReview(input: CreateMountainReviewAppInput!): Boolean! @auth(role : USER)
@@ -96,6 +102,8 @@ type Query {
   mountainDetail(input: MountainDetailAppInput!): Boolean! @auth(role : USER)
   "맛집 상세 조회"
   restaurantDetail(id: ID!): RestaurantAppDetail! @auth(role : USER)
+  "산 요약 정보"
+  mountainSummary(id: ID!): MountainSummary! @auth(role : USER)
   "샘플 데이터"
   sample(input: SampleAppItemInput!): SampleAppDetail! @auth(role : USER)
 }

--- a/app/src/test/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolverTest.kt
@@ -84,9 +84,9 @@ constructor(
 
       // then
       result.withSuccess("mountainSummary") {
-        //        expect("address").isEqualTo("test address")
-        //        expect("reviewCount").isEqualTo(0)
-        //        expect("rating").isEqualTo(0)
+        expect("address").isEqualTo("test address")
+        expect("reviewCount").isEqualTo(0)
+        expect("rating").isEqualTo(0)
       }
     }
   }

--- a/app/src/test/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolverTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/mountain/resolver/MountainAppQueryResolverTest.kt
@@ -1,0 +1,93 @@
+package com.santaclose.app.mountain.resolver
+
+import com.ninjasquad.springmockk.MockkBean
+import com.santaclose.app.mountain.service.MountainAppQueryService
+import com.santaclose.app.mountain.service.dto.MountainSummaryDto
+import com.santaclose.app.mountainReview.repository.dto.MountainRatingAverageDto
+import com.santaclose.app.util.AppContextMocker
+import com.santaclose.app.util.GraphqlBody
+import com.santaclose.app.util.gqlRequest
+import com.santaclose.app.util.withSuccess
+import com.santaclose.lib.entity.appUser.AppUser
+import com.santaclose.lib.entity.appUser.type.AppUserRole
+import com.santaclose.lib.entity.location.Location
+import com.santaclose.lib.entity.mountain.Mountain
+import com.santaclose.lib.entity.mountain.type.MountainManagement
+import io.mockk.coEvery
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+internal class MountainAppQueryResolverTest
+@Autowired
+constructor(
+  private val webTestClient: WebTestClient,
+  @MockkBean private val mountainAppQueryService: MountainAppQueryService,
+) : AppContextMocker() {
+
+  @Nested
+  inner class MountainSummary {
+    @Test
+    fun `산 요약정보를 가져온다`() {
+      // given
+      val query =
+        GraphqlBody(
+          """query {
+            |  mountainSummary(id: "123") {
+            |    id
+            |    address
+            |    imageUrl
+            |    rating
+            |    reviewCount
+            |    locations {
+            |      id
+            |      coordinate {
+            |        latitude
+            |        longitude
+            |      }
+            |    }
+            |  }
+            |}
+            """.trimMargin()
+        )
+      withMockUser(AppUserRole.USER)
+      val dto =
+        MountainSummaryDto(
+          mountain =
+            Mountain(
+              name = "test mountain",
+              images = mutableListOf("test.jpg"),
+              management = MountainManagement.MUNICIPAL,
+              altitude = 1000,
+              appUser = AppUser("name", "email", "socialId", AppUserRole.USER),
+              location =
+                Location.create(
+                  longitude = 10.0,
+                  latitude = 10.0,
+                  address = "test address",
+                  postcode = "123-1234",
+                ),
+            ),
+          restaurantLocations = emptyList(),
+          mountainRating = MountainRatingAverageDto.empty,
+        )
+
+      coEvery { mountainAppQueryService.findOneSummary(123) } returns dto
+
+      // when
+      val result = webTestClient.gqlRequest(query)
+
+      // then
+      result.withSuccess("mountainSummary") {
+        //        expect("address").isEqualTo("test address")
+        //        expect("reviewCount").isEqualTo(0)
+        //        expect("rating").isEqualTo(0)
+      }
+    }
+  }
+}

--- a/app/src/test/kotlin/com/santaclose/app/mountain/service/MountainAppQueryServiceTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/mountain/service/MountainAppQueryServiceTest.kt
@@ -16,7 +16,6 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import javax.persistence.EntityManager
 import javax.persistence.NoResultException
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -70,7 +69,7 @@ constructor(
   @Nested
   inner class FindOneSummary {
     @Test
-    fun `산 기본정보를 가져온다`() = runTest {
+    fun `산 기본정보를 가져온다`() {
       // given
       val appUser = em.createAppUser()
       val mountain = em.createMountain(appUser)
@@ -83,7 +82,7 @@ constructor(
     }
 
     @Test
-    fun `산 후기의 평균과 개수정보를 가져온다`() = runTest {
+    fun `산 후기의 평균과 개수정보를 가져온다`() {
       // given
       val appUser = em.createAppUser()
       val mountain = em.createMountain(appUser)
@@ -98,7 +97,7 @@ constructor(
     }
 
     @Test
-    fun `산과 연결된 식당의 위치정보를 가져온다`() = runTest {
+    fun `산과 연결된 식당의 위치정보를 가져온다`() {
       // given
       val appUser = em.createAppUser()
       val mountain = em.createMountain(appUser)

--- a/app/src/test/kotlin/com/santaclose/app/mountain/service/MountainAppQueryServiceTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/mountain/service/MountainAppQueryServiceTest.kt
@@ -3,15 +3,20 @@ package com.santaclose.app.mountain.service
 import com.expediagroup.graphql.generator.scalars.ID
 import com.santaclose.app.mountain.repository.MountainAppQueryRepositoryImpl
 import com.santaclose.app.mountainReview.repository.MountainReviewAppQueryRepositoryImpl
+import com.santaclose.app.restaurant.repository.RestaurantAppQueryRepositoryImpl
 import com.santaclose.app.util.createAppUser
 import com.santaclose.app.util.createMountain
+import com.santaclose.app.util.createMountainRestaurant
 import com.santaclose.app.util.createMountainReview
 import com.santaclose.app.util.createQueryFactory
+import com.santaclose.app.util.createRestaurant
 import com.santaclose.lib.web.toID
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import javax.persistence.EntityManager
 import javax.persistence.NoResultException
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -23,11 +28,12 @@ internal class MountainAppQueryServiceTest
 constructor(
   private val em: EntityManager,
 ) {
-  private val mountainAppQueryRepository = MountainAppQueryRepositoryImpl(em.createQueryFactory())
-  private val mountainReviewAppQueryRepository =
-    MountainReviewAppQueryRepositoryImpl(em.createQueryFactory())
   private val mountainAppQueryService =
-    MountainAppQueryService(mountainAppQueryRepository, mountainReviewAppQueryRepository)
+    MountainAppQueryService(
+      MountainAppQueryRepositoryImpl(em.createQueryFactory()),
+      MountainReviewAppQueryRepositoryImpl(em.createQueryFactory()),
+      RestaurantAppQueryRepositoryImpl(em.createQueryFactory())
+    )
 
   @Nested
   inner class FindDetail {
@@ -58,6 +64,53 @@ constructor(
 
       // then
       exception.message shouldBe "No entity found for query"
+    }
+  }
+
+  @Nested
+  inner class FindOneSummary {
+    @Test
+    fun `산 기본정보를 가져온다`() = runTest {
+      // given
+      val appUser = em.createAppUser()
+      val mountain = em.createMountain(appUser)
+
+      // when
+      val result = mountainAppQueryService.findOneSummary(mountain.id)
+
+      // then
+      result.mountain shouldBe mountain
+    }
+
+    @Test
+    fun `산 후기의 평균과 개수정보를 가져온다`() = runTest {
+      // given
+      val appUser = em.createAppUser()
+      val mountain = em.createMountain(appUser)
+      em.createMountainReview(appUser, mountain)
+
+      // when
+      val result = mountainAppQueryService.findOneSummary(mountain.id)
+
+      // then
+      result.mountainRating.average shouldBe 20.0 / 6
+      result.mountainRating.totalCount shouldBe 1
+    }
+
+    @Test
+    fun `산과 연결된 식당의 위치정보를 가져온다`() = runTest {
+      // given
+      val appUser = em.createAppUser()
+      val mountain = em.createMountain(appUser)
+      val restaurant = em.createRestaurant(appUser)
+      em.createMountainRestaurant(mountain, restaurant)
+
+      // when
+      val result = mountainAppQueryService.findOneSummary(mountain.id)
+
+      // then
+      result.restaurantLocations shouldHaveSize 1
+      result.restaurantLocations.first().id shouldBe restaurant.id
     }
   }
 }

--- a/app/src/test/kotlin/com/santaclose/app/mountainReview/repository/MountainReviewAppQueryRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/mountainReview/repository/MountainReviewAppQueryRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.santaclose.app.mountainReview.repository
 
+import com.santaclose.app.mountainReview.repository.dto.MountainRatingAverageDto
 import com.santaclose.app.util.createAppUser
 import com.santaclose.app.util.createMountain
 import com.santaclose.app.util.createMountainReview
@@ -61,6 +62,19 @@ constructor(
         average shouldBe 16.0 / 6
         totalCount shouldBe count
       }
+    }
+
+    @Test
+    fun `산 후기가 하나도 없는 경우 empty 를 반환한다`() {
+      // given
+      val appUser = em.createAppUser()
+      val mountain = em.createMountain(appUser)
+
+      // when
+      val dto = mountainReviewAppQueryRepository.findMountainRatingAverages(mountain.id)
+
+      // then
+      dto shouldBe MountainRatingAverageDto.empty
     }
   }
 }

--- a/app/src/test/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImplTest.kt
@@ -46,8 +46,8 @@ constructor(
       val appUser = em.createAppUser()
       val location = em.createLocation()
       val restaurant = em.createRestaurant(appUser, location)
-      // when
 
+      // when
       val result = restaurantAppQueryRepository.findOneWithLocation(restaurant.id)
 
       // then

--- a/app/src/test/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImplTest.kt
@@ -1,9 +1,11 @@
 package com.santaclose.app.restaurant.repository
 
 import com.santaclose.app.util.createAppUser
-import com.santaclose.app.util.createLocation
+import com.santaclose.app.util.createMountain
+import com.santaclose.app.util.createMountainRestaurant
 import com.santaclose.app.util.createQueryFactory
 import com.santaclose.app.util.createRestaurant
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import javax.persistence.EntityManager
 import org.junit.jupiter.api.Nested
@@ -14,9 +16,30 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 @DataJpaTest
 internal class RestaurantAppQueryRepositoryImplTest
 @Autowired
-constructor(private val em: EntityManager) {
+constructor(
+  private val em: EntityManager,
+) {
   private val restaurantAppQueryRepository =
     RestaurantAppQueryRepositoryImpl(em.createQueryFactory())
+
+  @Nested
+  inner class FindLocationByMountain {
+    @Test
+    fun `주어진 산과 연결된 식당좌표를 가져온다`() {
+      // given
+      val appUser = em.createAppUser()
+      val mountain = em.createMountain(appUser)
+      val restaurant = em.createRestaurant(appUser)
+      em.createMountainRestaurant(mountain, restaurant)
+
+      // when
+      val result = restaurantAppQueryRepository.findLocationByMountain(mountain.id)
+
+      // then
+      result shouldHaveSize 1
+      result[0].point.coordinates[0] shouldBe restaurant.location.point.coordinate
+    }
+  }
 
   @Nested
   inner class FindOneWithLocation {
@@ -26,16 +49,16 @@ constructor(private val em: EntityManager) {
       val appUser = em.createAppUser()
       val location = em.createLocation()
       val restaurant = em.createRestaurant(appUser, location)
-
       // when
-      val result = restaurantAppQueryRepository.findOneWithLocation(restaurant.id)
 
+
+      val result = restaurantAppQueryRepository.findOneWithLocation(restaurant.id)
       // then
-      result.apply {
         id shouldBe restaurant.id
+      result.apply {
         location.id shouldBe restaurant.location.id
-        location.point shouldBe restaurant.location.point
       }
+        location.point shouldBe restaurant.location.point
     }
   }
 }

--- a/app/src/test/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/restaurant/repository/RestaurantAppQueryRepositoryImplTest.kt
@@ -1,10 +1,7 @@
 package com.santaclose.app.restaurant.repository
 
-import com.santaclose.app.util.createAppUser
-import com.santaclose.app.util.createMountain
-import com.santaclose.app.util.createMountainRestaurant
-import com.santaclose.app.util.createQueryFactory
-import com.santaclose.app.util.createRestaurant
+import com.santaclose.app.util.*
+import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import javax.persistence.EntityManager
@@ -51,14 +48,14 @@ constructor(
       val restaurant = em.createRestaurant(appUser, location)
       // when
 
-
       val result = restaurantAppQueryRepository.findOneWithLocation(restaurant.id)
+
       // then
+      assertSoftly(result) {
         id shouldBe restaurant.id
-      result.apply {
         location.id shouldBe restaurant.location.id
-      }
         location.point shouldBe restaurant.location.point
+      }
     }
   }
 }

--- a/app/src/test/kotlin/com/santaclose/app/sample/arrow/ArrowTest.kt
+++ b/app/src/test/kotlin/com/santaclose/app/sample/arrow/ArrowTest.kt
@@ -3,7 +3,7 @@ package com.santaclose.app.sample.arrow
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
-import arrow.core.computations.option
+import arrow.core.continuations.option.eager
 import arrow.core.filterOption
 import arrow.core.some
 import io.kotest.assertions.arrow.core.shouldBeSome
@@ -38,14 +38,13 @@ internal class ArrowTest {
       //     .map { it + 10 }
 
       // when
-      val result =
-        option.eager<Int> {
-          val foo = getFoo().bind()
-          val bar = foo.bar.bind()
-          val result = divideBy100(bar.number).bind()
+      val result = eager {
+        val foo = getFoo().bind()
+        val bar = foo.bar.bind()
+        val result = divideBy100(bar.number).bind()
 
-          result + 100
-        }
+        result + 100
+      }
 
       // then
       result shouldBeSome 102

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ subprojects {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-    implementation("io.arrow-kt:arrow-core:1.0.1")
+    implementation("io.arrow-kt:arrow-core:1.1.2")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("aws.sdk.kotlin:s3:0.+")
     implementation("com.amazonaws:aws-java-sdk-s3:1.12.200")

--- a/lib/src/main/kotlin/com/santaclose/lib/auth/kakao/KakaoAuth.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/auth/kakao/KakaoAuth.kt
@@ -2,7 +2,7 @@ package com.santaclose.lib.auth.kakao
 
 import arrow.core.Either
 import arrow.core.Either.Companion.catch
-import arrow.core.computations.either
+import arrow.core.continuations.either
 import com.santaclose.lib.auth.Profile
 import com.santaclose.lib.logger.logger
 import io.netty.channel.ChannelOption

--- a/lib/src/main/kotlin/com/santaclose/lib/entity/mountain/Mountain.kt
+++ b/lib/src/main/kotlin/com/santaclose/lib/entity/mountain/Mountain.kt
@@ -5,6 +5,7 @@ import com.santaclose.lib.entity.BaseEntity
 import com.santaclose.lib.entity.appUser.AppUser
 import com.santaclose.lib.entity.location.Location
 import com.santaclose.lib.entity.mountain.type.MountainManagement
+import com.santaclose.lib.entity.mountainRestaurant.MountainRestaurant
 import javax.persistence.*
 import javax.persistence.FetchType.LAZY
 import javax.validation.constraints.NotNull
@@ -18,4 +19,6 @@ class Mountain(
   @field:NotNull var altitude: Int,
   @ManyToOne(fetch = LAZY) @field:NotNull var appUser: AppUser,
   @OneToOne(fetch = LAZY, cascade = [CascadeType.PERSIST]) var location: Location,
+  @OneToMany(fetch = LAZY, mappedBy = "mountain")
+  var mountainRestaurant: MutableList<MountainRestaurant> = mutableListOf(),
 ) : BaseEntity()


### PR DESCRIPTION
resolves #82

## 작업내용

- 지도 페이지에서 특정 산을 누른 경우 해당 산의 요약정보와 연결된 식당 좌표를 가져오는 api 구현하였습니다.
- 요청  : 산 ID
- 응답 
  - 산의 요약정보 (이름, 후기 수 , 평균, 대표이미지, 주소)
  - 연결된 식당 (식당 ID, 식당 좌표)

## 리뷰 참고사항

- arrow 라이브러리 업데이트 및 deprecated 대응 하였습니다.